### PR TITLE
Reduce allocations

### DIFF
--- a/algolia/search/index_objects.go
+++ b/algolia/search/index_objects.go
@@ -232,6 +232,15 @@ func (i *Index) Search(query string, opts ...interface{}) (res QueryRes, err err
 	return
 }
 
+// SearchTyped performs a search query according to the given query string and any
+// given query parameter among all the index records.
+func (i *Index) SearchTyped(query string, res interface{}, opts ...interface{}) (err error) {
+	body := searchReq{Params: transport.URLEncode(newSearchParams(query, opts...))}
+	path := i.path("/query")
+	err = i.transport.Request(&res, http.MethodPost, path, body, call.Read, opts...)
+	return
+}
+
 // FindObject searches iteratively through the search response `Hits`
 // field to find the first response hit that would match against the given
 // `filterFunc` function.

--- a/algolia/search/responses_search.go
+++ b/algolia/search/responses_search.go
@@ -42,6 +42,49 @@ type QueryRes struct {
 	RenderingContent           *RenderingContent                 `json:"renderingContent"`
 }
 
+// QueryResNoHits is like QueryRes but without hits.
+// Clients need to embed this structure to their struct with Hits field.
+//
+// Example:
+//  type Response struct {
+//		QueryResNoHits
+//		Hits []int `json:"Hits"`
+//  }
+type QueryResNoHits struct {
+	AppliedRules               []AppliedRule                     `json:"appliedRules"`
+	AppliedRelevancyStrictness int                               `json:"appliedRelevancyStrictness"`
+	AroundLatLng               string                            `json:"aroundLatLng"`
+	AutomaticRadius            string                            `json:"automaticRadius"`
+	ExhaustiveFacetsCount      bool                              `json:"exhaustiveFacetsCount"`
+	ExhaustiveNbHits           bool                              `json:"exhaustiveNbHits"`
+	Explain                    map[string]map[string]interface{} `json:"explain"`
+	Extensions                 map[string]map[string]interface{} `json:"extensions"`
+	Facets                     map[string]map[string]int         `json:"facets"`
+	FacetsStats                map[string]FacetStat              `json:"facets_stats"`
+	HitsPerPage                int                               `json:"hitsPerPage"`
+	Index                      string                            `json:"index"`
+	IndexUsed                  string                            `json:"indexUsed"`
+	Length                     int                               `json:"length"`
+	Message                    string                            `json:"message"`
+	NbHits                     int                               `json:"nbHits"`
+	NbPages                    int                               `json:"nbPages"`
+	NbSortedHits               int                               `json:"nbSortedHits"`
+	Offset                     int                               `json:"offset"`
+	Page                       int                               `json:"page"`
+	Params                     string                            `json:"params"`
+	ParsedQuery                string                            `json:"parsedQuery"`
+	ProcessingTimeMS           int                               `json:"processingTimeMS"`
+	Query                      string                            `json:"query"`
+	QueryAfterRemoval          string                            `json:"queryAfterRemoval"`
+	QueryID                    string                            `json:"queryID"`
+	ServerUsed                 string                            `json:"serverUsed"`
+	TimeoutCounts              bool                              `json:"timeoutCounts"`
+	TimeoutHits                bool                              `json:"timeoutHits"`
+	UserData                   []interface{}                     `json:"userData"`
+	ABTestVariantID            int                               `json:"abTestVariantID"`
+	RenderingContent           *RenderingContent                 `json:"renderingContent"`
+}
+
 type AppliedRule struct {
 	ObjectID string `json:"objectID"`
 }

--- a/algolia/transport/transport.go
+++ b/algolia/transport/transport.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"runtime"
@@ -307,14 +306,10 @@ func buildRequest(
 }
 
 func unmarshalTo(r io.ReadCloser, v interface{}) error {
-	body, err := ioutil.ReadAll(r)
+	err := json.NewDecoder(r).Decode(&v)
 	errClose := r.Close()
 	if err != nil {
-		return fmt.Errorf("cannot read body: %v", err)
-	}
-	err = json.Unmarshal(body, &v)
-	if err != nil {
-		return fmt.Errorf("cannot deserialize response's body: %v: %s", err, string(body))
+		return fmt.Errorf("cannot deserialize response's body: %v", err)
 	}
 	if errClose != nil {
 		return fmt.Errorf("cannot close response's body: %v", errClose)

--- a/algolia/transport/transport_test.go
+++ b/algolia/transport/transport_test.go
@@ -92,7 +92,7 @@ func TestUnmarshallTo(t *testing.T) {
 		expectedError error
 		expectedBody  fakeStruct
 	}{
-		{"<html>Non json answer</html>", fmt.Errorf("cannot deserialize response's body: invalid character '<' looking for beginning of value: <html>Non json answer</html>"), fakeStruct{}},
+		{"<html>Non json answer</html>", fmt.Errorf("cannot deserialize response's body: invalid character '<' looking for beginning of value"), fakeStruct{}},
 		{`{"attr":"value"}`, nil, fakeStruct{"value"}},
 	} {
 		bodyDeserialized := fakeStruct{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/algolia/algoliasearch-client-go/v3
+module github.com/FindHotel/algoliasearch-client-go/v3
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/FindHotel/algoliasearch-client-go/v3
+module github.com/algolia/algoliasearch-client-go/v3
 
 go 1.13
 


### PR DESCRIPTION

## Describe your change

Replace io.ReadAll + json.Unmarhal with json.NewDecoder
Added new SearchTyped method to serialize hits to user defined type instead of intermediate map[string]interface{}

## What problem is this fixing?

Reducing memory allocations
```
goos: darwin
goarch: arm64
pkg: github.com/FindHotel/sapi-backend/internal/hotel
BenchmarkGeoSearch/Typed-8                   393           2966783 ns/op         1779498 B/op      13271 allocs/op
BenchmarkGeoSearch/NonTyped-8                201           5796816 ns/op         3198823 B/op      33436 allocs/op
BenchmarkGeoSearch/NonTypedRA-8              208           5754820 ns/op         4127025 B/op      33450 allocs/op
PASS
ok      github.com/FindHotel/sapi-backend/internal/hotel        5.167s
```

Typed - version with typed response and json decoder
NonTyped - version with json decoder
NonTypedRA - version with io.ReadAll + json.Unmarshal

